### PR TITLE
Support large files in cwaitfor by using 64-bit integers

### DIFF
--- a/src/gettrk.fd/cwaitfor.c
+++ b/src/gettrk.fd/cwaitfor.c
@@ -4,17 +4,18 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <stdint.h>
 
-void c_run_command(int *retval,char *cmd) {
+void c_run_command(int64_t *retval,char *cmd) {
   *retval=system(cmd);
 }
 
-void cwaitfor(int *status, int *minage, int *minsize, int *maxwait,
-              int *sleeptime, char *filename) {
+void cwaitfor(int64_t *status, int64_t *minage, int64_t *minsize, int64_t *maxwait,
+              int64_t *sleeptime, char *filename) {
   struct stat s;
   time_t now=time(NULL);
-  int maxwaitv=*maxwait;
-  int size,age;
+  int64_t maxwaitv=*maxwait;
+  int64_t size,age;
   fprintf(stderr,"%s: cwaitfor with minage=%d minsize=%d maxwait=%d=%d sleeptime=%d\n",
           filename,*minage,*minsize,*maxwait,maxwaitv,*sleeptime);
   while(maxwaitv<0 || time(NULL)-now<maxwaitv) {
@@ -40,28 +41,28 @@ void cwaitfor(int *status, int *minage, int *minsize, int *maxwait,
   return;
 }
 
-void c_run_command_(int*r,char*c) { c_run_command(r,c); }
-void c_run_command__(int*r,char*c) { c_run_command(r,c); }
-void C_RUN_COMMAND(int*r,char*c) { c_run_command(r,c); }
-void C_RUN_COMMAND_(int*r,char*c) { c_run_command(r,c); }
-void C_RUN_COMMAND__(int*r,char*c) { c_run_command(r,c); }
+void c_run_command_(int64_t*r,char*c) { c_run_command(r,c); }
+void c_run_command__(int64_t*r,char*c) { c_run_command(r,c); }
+void C_RUN_COMMAND(int64_t*r,char*c) { c_run_command(r,c); }
+void C_RUN_COMMAND_(int64_t*r,char*c) { c_run_command(r,c); }
+void C_RUN_COMMAND__(int64_t*r,char*c) { c_run_command(r,c); }
 
-void cwaitfor_(int*a,int*b,int*c,int*d,int*e,char*f) {
+void cwaitfor_(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }
 
-void cwaitfor__(int*a,int*b,int*c,int*d,int*e,char*f) {
+void cwaitfor__(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }
 
-void CWAITFOR(int*a,int*b,int*c,int*d,int*e,char*f) {
+void CWAITFOR(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }
 
-void CWAITFOR_(int*a,int*b,int*c,int*d,int*e,char*f) {
+void CWAITFOR_(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }
 
-void CWAITFOR__(int*a,int*b,int*c,int*d,int*e,char*f) {
+void CWAITFOR__(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }

--- a/src/gettrk.fd/gettrk_main.f
+++ b/src/gettrk.fd/gettrk_main.f
@@ -702,7 +702,8 @@ c
       integer   ioaret,ioaxret,ifgcret,ifmret,igugret,isoiret,icccret
       integer   igrret,igmwret,iorret,ignret,iovret,icbret,igucret,ita
       integer   ifilret,ifret,iaret,isret,iotmret,iwa,iisa,sl_counter
-      integer   iicret,igcret,pfcret,igwcret,imbowret,iatret,ioapret
+      integer   iicret,igcret,igwcret,imbowret,iatret,ioapret
+      integer(kind=8) :: pfcret
       logical(1), allocatable :: valid_pt(:,:)
       logical(1), allocatable :: masked_outc(:,:),masked_out(:,:)
       logical(1) readflag(nreadparms),calcparm(maxtp,maxstorm)
@@ -722,8 +723,9 @@ c
       integer   igfwret,ioiret,igisret,iofwret,iowsret,igwsret,igscret
       integer   pdf_ct_tot,lugb,lugi,iret,icmcf,iccfh,ivt8f,icqwret
       integer   igsret,issta,iq850a,irha,ispfha,itempa,iomegaa
-      integer   waitfor_gfile_status,waitfor_ifile_status,ncfile_tmax
-      integer   wait_max_ifile_wait,ivr,r34_good_ct,itha,ilma,inctcv
+      integer   ncfile_tmax,ivr,r34_good_ct,itha,ilma,inctcv
+      integer(kind=8) :: waitfor_gfile_status,waitfor_ifile_status
+      integer(kind=8) :: wait_max_ifile_wait
       integer   ix_radii_beg,ix_radii_end,n_r34_iter
       integer   date_time(8),igarret
       character (len=10) big_ben(3)

--- a/src/gettrk.fd/gettrk_main.f
+++ b/src/gettrk.fd/gettrk_main.f
@@ -272,6 +272,9 @@ c                       bilin_int_uneven) with how Greenwich Meridian
 c                       wrapping was being handled.  I fixed the 
 c                       GM-wrapping in a few different areas in both
 c                       subroutines.
+c
+c   23-07-31  Marchok   Fixed an error in output_atcfunix where I had 
+c                       an extra comma in the output record.
 c 
 c
 c Input files:
@@ -10179,7 +10182,7 @@ c
       integer vradius(3,4),icps_vals(3)
       character  basinid*2,clatns*1,clonew*1,wcore_flag*1
       character comma_fill1*48,comma_fill2*31,comma_filler*79
-      character comma_fill1n*27,comma_fill2n*44
+      character comma_fill1n*25,comma_fill2n*44
 
       if ( verb .ge. 3 ) then
         print *,'TTT top of atcfunix, ist= ',ist,' ifh= ',ifcsthour
@@ -10389,7 +10392,7 @@ c      comma_fill1 = ',   0,   0,    ,   0,    ,   0,   0,           ,'
 c      comma_fill2 = '  ,   ,    ,   0,   0,   0,   0'
 c      comma_filler = comma_fill1//comma_fill2
 
-      comma_fill1n = ',   0,   0,    ,   0,    , '
+      comma_fill1n = ',   0,   0,    ,   0,    '
       comma_fill2n = ',           ,  ,   ,    ,   0,   0,   0,   0'
 
       if (trkrinfo%type == 'midlat' .or. trkrinfo%type == 'tcgen') then
@@ -10500,13 +10503,13 @@ c      comma_filler = comma_fill1//comma_fill2
 
    81 format (a2,', ',a2,', ',i10.10,', 03, ',a4,', ',i3.3,', ',i3,a1
      &       ,', ',i4,a1,', ',i3,', ',i4,', ',a12,4(', ',i4.4)
-     &       ,2(', ',i4),', ',i3,a27,2(', ',i3),a44
+     &       ,2(', ',i4),', ',i3,a25,2(', ',i3),a44
      &       ,',       THERMO PARAMS'
      &       ,3(', ',i7),', ',a1,', ',i2,', DT, -999, SHR82, ',i4,', '
      &       ,i3,', SST, ',i4,', ARMW',2(', ',i3))
    91 format (a2,', ',a4,', ',i10.10,', 03, ',a4,', ',i3.3,', ',i3,a1
      &       ,', ',i4,a1,', ',i3,', ',i4,', ',a12,4(', ',i4.4)
-     &       ,2(', ',i4),', ',i3,a27,2(', ',i3),a44
+     &       ,2(', ',i4),', ',i3,a25,2(', ',i3),a44
      &       ,',       THERMO PARAMS'
      &       ,3(', ',i7),', ',a1,', ',i2,', DT, -999, SHR82, ',i4,', '
      &       ,i3,', SST, ',i4,', ARMW',2(', ',i3)', ',a3)

--- a/src/gettrk.fd/gettrk_modules.f
+++ b/src/gettrk.fd/gettrk_modules.f
@@ -451,12 +451,12 @@ c
 c
       module waitfor_parms
         character*1 :: use_waitfor ! y or n, for waiting for input files
-        integer :: wait_min_age    ! min age (in seconds)... time since
-                                   ! last file modification
-        integer :: wait_min_size   ! minimum file size in bytes
-        integer :: wait_max_wait   ! max total wait time in seconds 
-        integer :: wait_sleeptime  ! number of seconds to wait between 
-                                   ! checks
+        integer(kind=8) :: wait_min_age    ! min age (in seconds)... time since
+                                           ! last file modification
+        integer(kind=8) :: wait_min_size   ! minimum file size in bytes
+        integer(kind=8) :: wait_max_wait   ! max total wait time in seconds 
+        integer(kind=8) :: wait_sleeptime  ! number of seconds to wait between 
+                                           ! checks
         integer, parameter :: pfc_cmd_len = 800
         character*1 :: use_per_fcst_command ! enable per_fcst_command
         character(pfc_cmd_len) :: per_fcst_command ! command to run every forecast time

--- a/src/gettrk.fd/module_waitfor.f
+++ b/src/gettrk.fd/module_waitfor.f
@@ -3,8 +3,8 @@
         private
         public :: waitfor, run_command
 
-        integer, parameter :: minage_def=30, minsize_def=1
-     &                       ,maxwait_def=-1, sleeptime_def=3
+        integer(kind=8), parameter :: minage_def=30, minsize_def=1
+     &                               ,maxwait_def=-1, sleeptime_def=3
 
       CONTAINS
         subroutine run_command(command,retval)
@@ -14,15 +14,15 @@
 !         Also, this way we get the command return status.
           implicit none
           character(*), intent(in) :: command
-          integer, intent(out) :: retval
+          integer(kind=8), intent(out) :: retval
           call run_cmd_helper(trim(command)//char(0),                   &
      &len_trim(command)+1,retval)
         end subroutine run_command
 
         subroutine run_cmd_helper(cmd,cmdlen,retval)
           implicit none
-          integer, intent(in) :: cmdlen
-          integer, intent(out) :: retval
+          integer(kind=8), intent(in) :: cmdlen
+          integer(kind=8), intent(out) :: retval
           character(*), intent(in) :: cmd(cmdlen)
 
           call c_run_command(retval,cmd)
@@ -32,13 +32,14 @@
      &                    ,sleeptime)
           implicit none
           character(*),intent(in) :: filename
-          integer, optional, intent(in) :: minage
-          integer, optional, intent(in) :: minsize
-          integer, optional, intent(in) :: maxwait
-          integer, optional, intent(in) :: sleeptime
-          integer, intent(out) :: status
+          integer(kind=8), optional, intent(in) :: minage
+          integer(kind=8), optional, intent(in) :: minsize
+          integer(kind=8), optional, intent(in) :: maxwait
+          integer(kind=8), optional, intent(in) :: sleeptime
+          integer(kind=8), intent(out) :: status
 
-          integer :: minage_in, minsize_in, maxwait_in, sleeptime_in
+          integer(kind=8) :: minage_in, minsize_in, maxwait_in
+          integer(kind=8) :: sleeptime_in
 
           status=99
 
@@ -72,17 +73,16 @@
 
         subroutine waitfor_helper(status,minage,minsize
      &        ,maxwait,sleeptime,filename,N)
-          integer, intent(in) :: minage,minsize,maxwait,sleeptime,N
+          integer(kind=8), intent(in) :: minage,minsize,maxwait
+          integer(kind=8), intent(in) :: sleeptime,N
           character(len=N),intent(in) :: filename
-          integer, intent(out) :: status
+          integer(kind=8), intent(out) :: status
 
           character(len=N+1) :: filename0
           character(len=1) :: null
-          integer :: np1
 
           null=char(0)
           filename0=filename//null
-          np1=N+1
 
           call cwaitfor(status,minage,minsize,maxwait,sleeptime
      &                 ,filename0)

--- a/src/gettrk.fd/module_waitfor.f
+++ b/src/gettrk.fd/module_waitfor.f
@@ -21,7 +21,7 @@
 
         subroutine run_cmd_helper(cmd,cmdlen,retval)
           implicit none
-          integer(kind=8), intent(in) :: cmdlen
+          integer, intent(in) :: cmdlen
           integer(kind=8), intent(out) :: retval
           character(*), intent(in) :: cmd(cmdlen)
 
@@ -74,7 +74,8 @@
         subroutine waitfor_helper(status,minage,minsize
      &        ,maxwait,sleeptime,filename,N)
           integer(kind=8), intent(in) :: minage,minsize,maxwait
-          integer(kind=8), intent(in) :: sleeptime,N
+          integer(kind=8), intent(in) :: sleeptime
+          integer, intent(in) :: N
           character(len=N),intent(in) :: filename
           integer(kind=8), intent(out) :: status
 


### PR DESCRIPTION
The tracker's waitfor cannot handle files 2GB or larger because it uses 32-bit integers to measure the file size. This changes the integers to 64 bits.

Fix hafs-community/HAFS/issues/215