### PR TITLE
[support/HAFS] Update path to modules on Jet

### DIFF
--- a/modulefiles/jet.lua
+++ b/modulefiles/jet.lua
@@ -6,7 +6,7 @@ prepend_path("MODULEPATH", "/contrib/sutils/modulefiles")
 load("sutils")
 load("hpss")
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 load(pathJoin("stack-intel", stack_intel_ver))


### PR DESCRIPTION
At GSL, we ran an HFIP 2024 experiment using this branch with our static-domain MPAS configuration. When lfs4 was migrated, we were all instructed to use spack-stack from a contrib module. 

Here, I'm proposing the updated change back to this branch since it's well-tested and could be useful for others who may also be using this code.
