### PR TITLE
Support for Intel LLVM on Ursa.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,17 @@ project(
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 message(CMAKE_MODULE_PATH " ${CMAKE_MODULE_PATH}")
-if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|GNU)$")
+if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|GNU|IntelLLVM)$")
   message(WARNING "Compiler not officially supported: ${CMAKE_Fortran_COMPILER_ID}")
 endif()
 
-if(NOT CMAKE_C_COMPILER_ID MATCHES "^(Intel|GNU)$")
+if(NOT CMAKE_C_COMPILER_ID MATCHES "^(Intel|GNU|IntelLLVM)$")
   message(WARNING "Compiler not officially supported: ${CMAKE_C_COMPILER_ID}")
 endif()
 
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(IntelLLVM)?$")
+  set(CMAKE_Fortran_FLAGS "-Wl,--allow-multiple-definition")
+endif()
 
 find_package(NetCDF REQUIRED C Fortran)
 #find_package(HDF5 REQUIRED)

--- a/src/gettrk.fd/CMakeLists.txt
+++ b/src/gettrk.fd/CMakeLists.txt
@@ -17,9 +17,12 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RELEASE")                                                                  
 endif()
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)(LLVM)?$")
   set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -O2 -traceback -fp-model precise -i4 -r8")
   set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}  -O0 -g -traceback -check all -ftrapuv  -fp-model precise -i4 -r8")
+  if(CMAKE_C_COMPILER_ID MATCHES "^(IntelLLVM)$")
+    set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}  -check nouninit")
+  endif()
 endif()
 
 option(USE_NOEXECSTACK "Direct the linker that executable stack is not needed" ON)

--- a/src/gettrk.fd/cwaitfor.c
+++ b/src/gettrk.fd/cwaitfor.c
@@ -17,8 +17,9 @@ void cwaitfor(int64_t *status, int64_t *minage, int64_t *minsize, int64_t *maxwa
   time_t now=time(NULL);
   int64_t maxwaitv=*maxwait;
   int64_t size,age;
-  fprintf(stderr,"%s: cwaitfor with minage=%d minsize=%d maxwait=%d=%d sleeptime=%d\n",
-          filename,*minage,*minsize,*maxwait,maxwaitv,*sleeptime);
+  fprintf(stderr,"%s: cwaitfor with minage=%lld minsize=%lld maxwait=%lld=%lld sleeptime=%lld\n",
+          filename, (long long)*minage, (long long)*minsize, (long long)*maxwait,
+          (long long)maxwaitv, (long long)*sleeptime);
   while(maxwaitv<0 || time(NULL)-now<maxwaitv) {
     if(!stat(filename,&s)) {
       size=s.st_size;
@@ -28,13 +29,13 @@ void cwaitfor(int64_t *status, int64_t *minage, int64_t *minsize, int64_t *maxwa
         *status=0;
         return;
       } else {
-        fprintf(stderr,"%s: Not ready yet.  Size=%d, age=%d, min size=%d, min age=%d\n",
-               filename,size,age,*minsize,*minage);
+        fprintf(stderr,"%s: Not ready yet.  Size=%lld, age=%lld, min size=%lld, min age=%lld\n",
+                filename,(long long)size,(long long)age,(long long)*minsize,(long long)*minage);
       }
     } else {
       fprintf(stderr,"%s: Not available yet.",filename);
     }
-    fprintf(stderr,"%s: sleep %d\n",filename,*sleeptime);
+    fprintf(stderr,"%s: sleep %lld\n",filename,(long long)*sleeptime);
     sleep(*sleeptime);
   }
 

--- a/src/gettrk.fd/gettrk_main.f
+++ b/src/gettrk.fd/gettrk_main.f
@@ -4637,7 +4637,7 @@ c
       logical(4)  file_open4,file_open5
       character fnameg*7,fnamei*7,fnameo*7
       character(*) gfilename,ifilename
-      character(120) gopen_g_file,gopen_i_file
+      character(len=:), allocatable :: gopen_g_file,gopen_i_file
       integer  igoret,iioret,iooret,lugb,lugi,lout,iret,nlen1,nlen2
 
       iret=0
@@ -4656,9 +4656,15 @@ c
 
         print *,'in open_grib_files in multi else part....'
 
+        write(0,*) 'gfilename',gfilename
+        write(0,*) 'ifilename',ifilename
+
         nlen1        = len_trim(gfilename)
+        allocate(character(len=nlen1) :: gopen_g_file)
         gopen_g_file = trim(gfilename(1:nlen1))
+
         nlen2        = len_trim(ifilename)
+        allocate(character(len=nlen2) :: gopen_i_file)
         gopen_i_file = trim(ifilename(1:nlen2))
 
         print *,'  lugb= ',lugb,'  lugi= ',lugi
@@ -4667,8 +4673,8 @@ c
         print *,'gopen_i_file= ',gopen_i_file
 
         write (6,81) gopen_g_file,gopen_i_file
-   81   format (1x,'tpm gopen_g_file= ...',a<nlen1>
-     &         ,'...  gopen_i_file= ...',a<nlen2>,'...')
+   81   format (1x,'tpm gopen_g_file= ...',a
+     &         ,'...  gopen_i_file= ...',a,'...')
 
         print *,'gopen_g_file= ',gopen_g_file,'....'
         print *,'gopen_i_file= ',gopen_i_file,'....'
@@ -4739,9 +4745,13 @@ c
         endif
 
         iret = 113
+        if(allocated(gopen_i_file)) deallocate(gopen_i_file)
+        if(allocated(gopen_g_file)) deallocate(gopen_g_file)
         return
       endif
 
+      if(allocated(gopen_i_file)) deallocate(gopen_i_file)
+      if(allocated(gopen_g_file)) deallocate(gopen_g_file)
       return
       end
 c

--- a/src/supvit.fd/CMakeLists.txt
+++ b/src/supvit.fd/CMakeLists.txt
@@ -14,9 +14,12 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RELEASE")                                                                  
 endif()
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)(LLVM)?$")
   set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -O2 -fp-model precise -i4 -r8")
   set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0 -g -traceback -check all -ftrapuv -fp-model precise -i4 -r8")
+  if(CMAKE_C_COMPILER_ID MATCHES "^(IntelLLVM)$")
+    set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}  -check nouninit")
+  endif()
 endif()
 
 add_executable(${exe_name} ${fortran_srcs})

--- a/src/tave.fd/CMakeLists.txt
+++ b/src/tave.fd/CMakeLists.txt
@@ -14,9 +14,12 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RELEASE")                                                                  
 endif()
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)(LLVM)?$")
   set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -O2 -fp-model precise -i4 -r8")
   set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}  -O0 -g -traceback -check all -ftrapuv -fp-model precise -i4 -r8")
+  if(CMAKE_C_COMPILER_ID MATCHES "^(IntelLLVM)$")
+    set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}  -check nouninit")
+  endif()
 endif()
 
 add_executable(${exe_name} ${fortran_srcs})

--- a/src/vint.fd/CMakeLists.txt
+++ b/src/vint.fd/CMakeLists.txt
@@ -14,9 +14,12 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RELEASE")                                                                  
 endif()
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)(LLVM)?$")
   set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -O2 -fp-model precise -i4 -r8")
   set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0 -g -traceback -check all -ftrapuv -fp-model precise -i4 -r8")
+  if(CMAKE_C_COMPILER_ID MATCHES "^(IntelLLVM)$")
+    set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}  -check nouninit")
+  endif()
 endif()
 
 add_executable(${exe_name} ${fortran_srcs})


### PR DESCRIPTION
Updates cmake files to be aware of the Intel LLVM compiler.
Fixes some bugs that cause that compiler to fail.

1. Change regex to detect compiler with IntelLLVM.
2. Disable the `uninit` check when using IntelLLVM since that can't compile on Ursa due to the missing `libm.a`
3. Use `-Wl,--allow-multiple-definition` with IntelLLVM since that option is off by default.
4. Fix a type mismatch in `cwaitfor.c`
5. Don't use an unsupported feature to print text in one spot in gettrk.f. That crashes with IntelLLVM. Instead, use a modern alternative.

Tested with this test case:

URSA: `/scratch3/BMC/wrfruc/Samuel.Trahan/mpashfip/trackerdata/run`